### PR TITLE
Make graphviz code run `dot` to create PDFs in addition to the raw dotfile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,19 +31,18 @@ pub fn test_harness(dir_name: &str) -> eyre::Result<()> {
         .output()
         .wrap_err("failed to run souffle")?;
 
-    let dot = Command::new("python3")
+    let dot_path = output_path.join("graph.dot");
+    let _ = Command::new("python3")
         .args(&[
             manifest_dir
                 .join("graphviz/graphviz.py")
                 .display()
                 .to_string(),
-            facts_path.display().to_string(),
-            output_path.display().to_string(),
+            path.display().to_string(),
+            dot_path.display().to_string(),
         ])
         .output()
         .wrap_err("failed to run python3")?;
-
-    std::fs::write(output_path.join("graph.dot"), dot.stdout)?;
 
     if std::env::var("BLESS").is_ok() {
         let status = Command::new("cp")


### PR DESCRIPTION
This way one can look at the graph without needing to visualize it oneself first (either via a program or indirectly through HackMD). Of course that only works if `dot` is installed, but running/testing will not fail if it isn't. The script will just not build the PDF in that case.