### PR TITLE
Record spans when parsing `Statement`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,5 @@
+use crate::span::Spanned as Sp;
+
 #[derive(Clone, Debug)]
 pub struct Program {
     pub struct_decls: Vec<StructDecl>,
@@ -36,7 +38,7 @@ pub enum GenericDecl {
 #[derive(Clone, Debug)]
 pub struct BasicBlock {
     pub name: Name,
-    pub statements: Vec<Statement>,
+    pub statements: Vec<Sp<Statement>>,
     pub successors: Vec<Name>,
 }
 

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::ast;
+use crate::span::{Span, Spanned as Sp, WithSpan};
 
 #[cfg(test)]
 mod test;
@@ -110,7 +111,7 @@ peg::parser! {
         rule comma() -> () = _ "," _ { }
 
         rule basic_block() -> ast::BasicBlock = (
-            name:ident() _ ":" _ "{" _ statements:statement()**__ _ successors:goto() _ "}" {
+            name:ident() _ ":" _ "{" _ statements:sp(<statement()>)**__ _ successors:goto() _ "}" {
                 ast::BasicBlock { name, statements, successors }
             }
         )
@@ -154,6 +155,9 @@ peg::parser! {
             t.to_string()
         }
 
+        rule sp<T>(t: rule<T>) -> Sp<T> = start:position!() inner:t() end:position!() {
+            inner.at(Span::new(start, end))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod span;
 mod ast;
 mod ast_parser;
 mod fact_parser;

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,0 +1,86 @@
+use std::ops;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    pub const fn new(start: usize, end: usize) -> Self {
+        Span { start, end }
+    }
+
+    pub const fn dummy() -> Self {
+        Span::new(0, 0)
+    }
+
+    pub const fn start(self) -> usize {
+        self.start
+    }
+
+    pub const fn end(self) -> usize {
+        self.end
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Spanned<T> {
+    span: Span,
+    inner: T,
+}
+
+impl<T> Spanned<T> {
+    pub const fn new(inner: T, span: Span) -> Self {
+        Spanned { span, inner }
+    }
+
+    pub const fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn as_ref(this: &Self) -> Spanned<&T> {
+        Spanned {
+            inner: &this.inner,
+            span: this.span,
+        }
+    }
+
+    pub fn map<U>(this: Self, f: impl FnOnce(T) -> U) -> Spanned<U> {
+        Spanned {
+            inner: f(this.inner),
+            span: this.span,
+        }
+    }
+}
+
+pub trait WithSpan: Sized {
+    fn at(self, span: Span) -> Spanned<Self>;
+}
+
+impl<T> WithSpan for T {
+    fn at(self, span: Span) -> Spanned<Self> {
+        Spanned {
+            inner: self,
+            span,
+        }
+    }
+}
+
+impl<T> ops::Deref for Spanned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> ops::DerefMut for Spanned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}


### PR DESCRIPTION
Allows #4 to add labels to CFG nodes. 

Uses [PEG's rule arguments](https://github.com/kevinmehall/rust-peg/blob/master/tests/run-pass/rule_args.rs) (similar to LALRPOP macros). It should be straightforward to extend this to the rest of the AST as needed.