### PR TITLE
Rename `Statement::Drop` to `Statement::Expr`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,8 +42,11 @@ pub struct BasicBlock {
 
 #[derive(Clone, Debug)]
 pub enum Statement {
+    /// An assignment (`place = expr;`).
     Assign(Place, Expr),
-    Drop(Expr),
+
+    /// A bare expression (`expr;`).
+    Expr(Expr),
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -122,7 +122,7 @@ peg::parser! {
 
         rule statement() -> ast::Statement = (
             place:place() _ "=" _ expr:expr() _ ";" { ast::Statement::Assign(place, expr) } /
-            expr:expr() _ ";" { ast::Statement::Drop(expr) }
+            expr:expr() _ ";" { ast::Statement::Expr(expr) }
         )
 
         rule expr() -> ast::Expr = (


### PR DESCRIPTION
This is the name used by `rustc`. `Drop` suggests additional semantics.

This came up while reviewing #4.