### PR TITLE
A pair of minor fixes 

### DIFF
--- a/src/fact_parser.rs
+++ b/src/fact_parser.rs
@@ -32,7 +32,7 @@ pub struct Fact {
 
 peg::parser! {
     grammar fact_parser() for str {
-        pub rule program() -> Program = comment()* _ g:fact()**__ _ n:statement()**__ {
+        pub rule program() -> Program = comment()* _ g:fact()**__ _ n:statement()**__ _ {
             Program {
                 global_facts: g,
                  statements: n

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -199,6 +199,7 @@ pub(crate) fn create_graph(fact_directory: &Path, output_file_path: &Path) {
     let mut output_file = fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&output_file_path)
         .expect("could not open output file");
     output_file


### PR DESCRIPTION
- Truncate graphviz files before overwriting them.
- Allow trailing whitespace in fact files.