### PR TITLE
Parse deref projections like Rust would

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -89,6 +89,16 @@ pub enum Ty {
     },
 }
 
+impl Ty {
+    /// If this is a reference type, returns the type of the target of that reference.
+    pub fn target(&self) -> Option<&Ty> {
+        match self {
+            Self::Ref { ty, .. } | Self::RefMut { ty, .. } => Some(&*ty),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Parameter {
     Origin(Name),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -96,9 +96,19 @@ pub enum Parameter {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum Projection {
+    Field(Name),
+    Deref,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Place {
     pub base: Name,
-    pub fields: Vec<Name>,
+
+    /// Any projections on `base`, starting from the innermost one.
+    ///
+    /// For example, `x.f1.f2` would give `vec!["f1", "f2"]`.
+    pub projections: Vec<Projection>,
 }
 
 pub type Name = String;

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -129,7 +129,7 @@ peg::parser! {
             "(" _ ")" { ast::Expr::Unit }
         )
 
-        rule place() -> ast::Place = precedence!{
+        pub rule place() -> ast::Place = precedence!{
             "*" _ inner:@ {
                 let mut inner = inner;
                 inner.projections.push(ast::Projection::Deref);
@@ -170,3 +170,5 @@ peg::parser! {
 pub fn parse_ast(input: &str) -> eyre::Result<ast::Program> {
     Ok(ast_parser::program(input)?)
 }
+
+pub use self::ast_parser::place;

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -129,10 +129,22 @@ peg::parser! {
             "(" _ ")" { ast::Expr::Unit }
         )
 
-        rule place() -> ast::Place = (
-            base:ident() _ dot() _ fields:ident()**dot() { ast::Place { base, fields } } /
-            base:ident() { ast::Place { base, fields: vec![] } }
-        )
+        rule place() -> ast::Place = precedence!{
+            "*" _ inner:@ {
+                let mut inner = inner;
+                inner.projections.push(ast::Projection::Deref);
+                inner
+            }
+            --
+            inner:@ _ "." _ field:ident() {
+                let mut inner = inner;
+                inner.projections.push(ast::Projection::Field(field));
+                inner
+            }
+            --
+            base:ident() { ast::Place { base, projections: vec![] } }
+            "(" _ inner:place() _ ")" { inner }
+        }
 
         rule access_kind() -> ast::AccessKind = (
             "copy" { ast::AccessKind::Copy } /
@@ -141,9 +153,7 @@ peg::parser! {
             "&" _ o:origin_ident() { ast::AccessKind::Borrow(o) }
         )
 
-        rule dot() -> () = _ "." _
-
-        rule ident() -> ast::Name = t:$(['a'..='z' | 'A'..='Z' | '_' | '0' ..= '9' | '*' ]+) {
+        rule ident() -> ast::Name = t:$(['a'..='z' | 'A'..='Z' | '_' | '0' ..= '9' ]+) {
             t.to_string()
         }
 

--- a/src/ast_parser/snapshots/polonius__ast_parser__test__example_issue_47680.snap
+++ b/src/ast_parser/snapshots/polonius__ast_parser__test__example_issue_47680.snap
@@ -50,7 +50,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "temp",
-                            fields: [],
+                            projections: [],
                         },
                         Access {
                             kind: BorrowMut(
@@ -58,7 +58,7 @@ Program {
                             ),
                             place: Place {
                                 base: "Thing",
-                                fields: [],
+                                projections: [],
                             },
                         },
                     ),
@@ -79,15 +79,17 @@ Program {
                     inner: Assign(
                         Place {
                             base: "t0",
-                            fields: [],
+                            projections: [],
                         },
                         Access {
                             kind: BorrowMut(
                                 "'L_*temp",
                             ),
                             place: Place {
-                                base: "*temp",
-                                fields: [],
+                                base: "temp",
+                                projections: [
+                                    Deref,
+                                ],
                             },
                         },
                     ),
@@ -100,7 +102,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "v",
-                            fields: [],
+                            projections: [],
                         },
                         Call {
                             name: "MaybeNext",
@@ -109,7 +111,7 @@ Program {
                                     kind: Move,
                                     place: Place {
                                         base: "t0",
-                                        fields: [],
+                                        projections: [],
                                     },
                                 },
                             ],
@@ -133,13 +135,13 @@ Program {
                     inner: Assign(
                         Place {
                             base: "temp",
-                            fields: [],
+                            projections: [],
                         },
                         Access {
                             kind: Move,
                             place: Place {
                                 base: "v",
-                                fields: [],
+                                projections: [],
                             },
                         },
                     ),

--- a/src/ast_parser/snapshots/polonius__ast_parser__test__example_vec_temp.snap
+++ b/src/ast_parser/snapshots/polonius__ast_parser__test__example_vec_temp.snap
@@ -62,7 +62,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "x",
-                            fields: [],
+                            projections: [],
                         },
                         Number {
                             value: 22,
@@ -77,7 +77,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "v",
-                            fields: [],
+                            projections: [],
                         },
                         Call {
                             name: "Vec_new",
@@ -93,7 +93,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "p",
-                            fields: [],
+                            projections: [],
                         },
                         Access {
                             kind: Borrow(
@@ -101,7 +101,7 @@ Program {
                             ),
                             place: Place {
                                 base: "x",
-                                fields: [],
+                                projections: [],
                             },
                         },
                     ),
@@ -114,7 +114,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "tmp",
-                            fields: [],
+                            projections: [],
                         },
                         Access {
                             kind: BorrowMut(
@@ -122,7 +122,7 @@ Program {
                             ),
                             place: Place {
                                 base: "v",
-                                fields: [],
+                                projections: [],
                             },
                         },
                     ),
@@ -140,14 +140,14 @@ Program {
                                     kind: Move,
                                     place: Place {
                                         base: "tmp",
-                                        fields: [],
+                                        projections: [],
                                     },
                                 },
                                 Access {
                                     kind: Move,
                                     place: Place {
                                         base: "p",
-                                        fields: [],
+                                        projections: [],
                                     },
                                 },
                             ],
@@ -162,7 +162,7 @@ Program {
                     inner: Assign(
                         Place {
                             base: "x",
-                            fields: [],
+                            projections: [],
                         },
                         Number {
                             value: 44,
@@ -182,7 +182,7 @@ Program {
                                     kind: Copy,
                                     place: Place {
                                         base: "v",
-                                        fields: [],
+                                        projections: [],
                                     },
                                 },
                             ],

--- a/src/ast_parser/test.rs
+++ b/src/ast_parser/test.rs
@@ -65,7 +65,7 @@ fn statement_test() {
                         inner: Assign(
                             Place {
                                 base: "x",
-                                fields: [],
+                                projections: [],
                             },
                             Number {
                                 value: 22,
@@ -113,7 +113,7 @@ fn borrow_test() {
                         inner: Assign(
                             Place {
                                 base: "x",
-                                fields: [],
+                                projections: [],
                             },
                             Number {
                                 value: 22,
@@ -128,7 +128,7 @@ fn borrow_test() {
                         inner: Assign(
                             Place {
                                 base: "y",
-                                fields: [],
+                                projections: [],
                             },
                             Access {
                                 kind: Borrow(
@@ -136,7 +136,7 @@ fn borrow_test() {
                                 ),
                                 place: Place {
                                     base: "x",
-                                    fields: [],
+                                    projections: [],
                                 },
                             },
                         ),
@@ -149,7 +149,7 @@ fn borrow_test() {
                         inner: Assign(
                             Place {
                                 base: "z",
-                                fields: [],
+                                projections: [],
                             },
                             Access {
                                 kind: BorrowMut(
@@ -157,7 +157,7 @@ fn borrow_test() {
                                 ),
                                 place: Place {
                                     base: "x",
-                                    fields: [],
+                                    projections: [],
                                 },
                             },
                         ),
@@ -228,7 +228,7 @@ fn copy_move_test() {
                         inner: Assign(
                             Place {
                                 base: "x",
-                                fields: [],
+                                projections: [],
                             },
                             Number {
                                 value: 22,
@@ -243,13 +243,13 @@ fn copy_move_test() {
                         inner: Assign(
                             Place {
                                 base: "y",
-                                fields: [],
+                                projections: [],
                             },
                             Access {
                                 kind: Copy,
                                 place: Place {
                                     base: "x",
-                                    fields: [],
+                                    projections: [],
                                 },
                             },
                         ),
@@ -262,13 +262,13 @@ fn copy_move_test() {
                         inner: Assign(
                             Place {
                                 base: "z",
-                                fields: [],
+                                projections: [],
                             },
                             Access {
                                 kind: Move,
                                 place: Place {
                                     base: "x",
-                                    fields: [],
+                                    projections: [],
                                 },
                             },
                         ),

--- a/src/fact_emitter/test.rs
+++ b/src/fact_emitter/test.rs
@@ -7,6 +7,7 @@ mod invalidate_origin;
 
 use super::*;
 use crate::ast_parser::test::expect_parse;
+use crate::ast_parser as parse;
 use insta::assert_debug_snapshot;
 
 pub(crate) fn expect_facts(input: &str) -> Facts {
@@ -22,23 +23,17 @@ fn create_emitter(input: &str) -> FactEmitter {
     FactEmitter::new(program, input, true)
 }
 
-fn place_at_path(path: &str) -> Place {
-    let mut path: Vec<_> = path.split('.').map(ToString::to_string).collect();
-    let base = path.remove(0);
-    Place { base, fields: path }
-}
-
 // Returns the type of the given place's path in the given program.
 fn find_ty(program: &str, path: &str) -> Ty {
     let emitter = create_emitter(program);
-    let place = place_at_path(path);
+    let place = parse::place(path).expect("Invalid place");
     emitter.ty_of_place(&place).clone()
 }
 
 // Returns the origins present in the type of the given place's path in the given program.
 fn find_origins(program: &str, path: &str) -> Vec<Origin> {
     let emitter = create_emitter(program);
-    let place = place_at_path(path);
+    let place = parse::place(path).expect("Invalid place");
     emitter.origins_of_place(&place)
 }
 

--- a/src/fact_emitter/test.rs
+++ b/src/fact_emitter/test.rs
@@ -93,7 +93,7 @@ fn type_of_vars() {
     //     struct Ref<'a, T> { ref: &'a T }
     //     let r: Ref<'r, Vec<i32>>;
     // ";
-    // assert_debug_snapshot!(ty_of_place(program, "r.ref"), @"");
+    // assert_debug_snapshot!(find_ty(program, "r.ref"), @"");
 
     // TODO ?
     // // generic struct: origins and types, and derefs
@@ -102,7 +102,7 @@ fn type_of_vars() {
     //     struct Ref<'a, T> { ref: &'a T }
     //     let r: Ref<'r, Vec<i32>>;
     // ";
-    // assert_eq!(ty_of_place(program, "r.ref.e"), Ty::I32);
+    // assert_eq!(find_ty(program, "(*r.ref).e"), Ty::I32);
 }
 
 #[test]

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use std::ops;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
A redo of #9.

Unlike #9, `*` is still allowed in `origin_ident`s but is no longer allowed in normal ones.