### PR TITLE
Fix whitespace errors according to git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    
+
 jobs:
   test:
     name: Run tests
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
+      - name: Check for whitespace errors
+        run: git fetch origin main && git diff --check origin/main
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1

--- a/src/fact_emitter.rs
+++ b/src/fact_emitter.rs
@@ -159,7 +159,7 @@ impl<'a> FactEmitter<'a> {
                         facts.clear_origin.push((origin.clone(), node.clone()));
                     }
 
-                    // TODO: the following is wrong and simplistic, see 
+                    // TODO: the following is wrong and simplistic, see
                     // https://github.com/nikomatsakis/polonius.next/pull/4#discussion_r739325010
                     // but will be fixed by https://github.com/nikomatsakis/polonius.next/pull/10
                     if !lhs_ty.is_ref() {

--- a/src/fact_emitter/examples/canonical_liveness.rs
+++ b/src/fact_emitter/examples/canonical_liveness.rs
@@ -20,37 +20,37 @@ fn canonical_liveness() {
     ";
     assert_display_snapshot!(expect_facts(program), @r###"
     a: "p = 22" {
-    	invalidate_origin('L_p)
-    	goto b
+        invalidate_origin('L_p)
+        goto b
     }
 
     b: "q = 44" {
-    	invalidate_origin('L_q)
-    	goto c
+        invalidate_origin('L_q)
+        goto c
     }
 
     c: "x = &'L_p p" {
-    	clear_origin('x)
-    	clear_origin('L_p)
-    	introduce_subset('L_p, 'x)
-    	goto d
+        clear_origin('x)
+        clear_origin('L_p)
+        introduce_subset('L_p, 'x)
+        goto d
     }
 
     d: "x = &'L_q q" {
-    	clear_origin('x)
-    	clear_origin('L_q)
-    	introduce_subset('L_q, 'x)
-    	goto e
+        clear_origin('x)
+        clear_origin('L_q)
+        introduce_subset('L_q, 'x)
+        goto e
     }
 
     e: "p = 33" {
-    	invalidate_origin('L_p)
-    	goto f
+        invalidate_origin('L_p)
+        goto f
     }
 
     f: "use(move x)" {
-    	access_origin('x)
-    	goto
+        access_origin('x)
+        goto
     }
     "###);
 }
@@ -71,25 +71,25 @@ fn canonical_liveness_err() {
     ";
     assert_display_snapshot!(expect_facts(program), @r###"
     a: "p = 22" {
-    	invalidate_origin('L_p)
-    	goto b
+        invalidate_origin('L_p)
+        goto b
     }
 
     b: "x = &'L_p p" {
-    	clear_origin('x)
-    	clear_origin('L_p)
-    	introduce_subset('L_p, 'x)
-    	goto c
+        clear_origin('x)
+        clear_origin('L_p)
+        introduce_subset('L_p, 'x)
+        goto c
     }
 
     c: "p = 33" {
-    	invalidate_origin('L_p)
-    	goto d
+        invalidate_origin('L_p)
+        goto d
     }
 
     d: "use(move x)" {
-    	access_origin('x)
-    	goto
+        access_origin('x)
+        goto
     }
     "###);
 }

--- a/src/fact_emitter/examples/issue_47680.rs
+++ b/src/fact_emitter/examples/issue_47680.rs
@@ -42,41 +42,41 @@ fn issue_47680() {
 
     assert_display_snapshot!(expect_facts(program), @r###"
     a: "temp = &'L_Thing mut thing" {
-    	invalidate_origin('L_Thing)
-    	clear_origin('temp)
-    	clear_origin('L_Thing)
-    	introduce_subset('L_Thing, 'temp)
-    	goto b
+        invalidate_origin('L_Thing)
+        clear_origin('temp)
+        clear_origin('L_Thing)
+        introduce_subset('L_Thing, 'temp)
+        goto b
     }
 
     b: "t0 = &'L_*temp mut *temp" {
-    	access_origin('temp)
-    	invalidate_origin('L_*temp)
-    	clear_origin('t0)
-    	clear_origin('L_*temp)
-    	introduce_subset('L_*temp, 't0)
-    	goto c
+        access_origin('temp)
+        invalidate_origin('L_*temp)
+        clear_origin('t0)
+        clear_origin('L_*temp)
+        introduce_subset('L_*temp, 't0)
+        goto c
     }
 
     c: "v = MaybeNext(move t0)" {
-    	access_origin('t0)
-    	clear_origin('v)
-    	goto d e
+        access_origin('t0)
+        clear_origin('v)
+        goto d e
     }
 
     d: "temp = move v" {
-    	access_origin('v)
-    	clear_origin('temp)
-    	introduce_subset('v, 'temp)
-    	goto f
+        access_origin('v)
+        clear_origin('temp)
+        introduce_subset('v, 'temp)
+        goto f
     }
 
     e: "(pass)" {
-    	goto f
+        goto f
     }
 
     f: "(pass)" {
-    	goto b
+        goto b
     }
     "###);
 }

--- a/src/fact_emitter/examples/mod.rs
+++ b/src/fact_emitter/examples/mod.rs
@@ -24,25 +24,25 @@ fn example_a() {
 
     assert_display_snapshot!(expect_facts(program), @r###"
     a: "x = 3" {
-    	invalidate_origin('L_x)
-    	goto b
+        invalidate_origin('L_x)
+        goto b
     }
 
     b: "y = &'L_x x" {
-    	clear_origin('y)
-    	clear_origin('L_x)
-    	introduce_subset('L_x, 'y)
-    	goto c
+        clear_origin('y)
+        clear_origin('L_x)
+        introduce_subset('L_x, 'y)
+        goto c
     }
 
     c: "x = 4" {
-    	invalidate_origin('L_x)
-    	goto d
+        invalidate_origin('L_x)
+        goto d
     }
 
     d: "use(move y)" {
-    	access_origin('y)
-    	goto
+        access_origin('y)
+        goto
     }
     "###);
 }

--- a/src/fact_emitter/examples/vec_temp.rs
+++ b/src/fact_emitter/examples/vec_temp.rs
@@ -31,50 +31,50 @@ fn vec_temp() {
 
     assert_display_snapshot!(expect_facts(program), @r###"
     a: "x = 22" {
-    	invalidate_origin('L_x)
-    	goto b
+        invalidate_origin('L_x)
+        goto b
     }
 
     b: "v = Vec_new()" {
-    	invalidate_origin('L_v)
-    	clear_origin('v)
-    	goto c
+        invalidate_origin('L_v)
+        clear_origin('v)
+        goto c
     }
 
     c: "p = &'L_x x" {
-    	clear_origin('p)
-    	clear_origin('L_x)
-    	introduce_subset('L_x, 'p)
-    	goto d
+        clear_origin('p)
+        clear_origin('L_x)
+        introduce_subset('L_x, 'p)
+        goto d
     }
 
     d: "tmp = &'L_v mut v" {
-    	access_origin('v)
-    	invalidate_origin('L_v)
-    	clear_origin('tmp0)
-    	clear_origin('tmp1)
-    	clear_origin('L_v)
-    	introduce_subset('L_v, 'tmp0)
-    	introduce_subset('v, 'tmp1)
-    	introduce_subset('tmp1, 'v)
-    	goto e
+        access_origin('v)
+        invalidate_origin('L_v)
+        clear_origin('tmp0)
+        clear_origin('tmp1)
+        clear_origin('L_v)
+        introduce_subset('L_v, 'tmp0)
+        introduce_subset('v, 'tmp1)
+        introduce_subset('tmp1, 'v)
+        goto e
     }
 
     e: "Vec_push(move tmp, move p)" {
-    	access_origin('tmp0)
-    	access_origin('tmp1)
-    	access_origin('p)
-    	goto f
+        access_origin('tmp0)
+        access_origin('tmp1)
+        access_origin('p)
+        goto f
     }
 
     f: "x = 23" {
-    	invalidate_origin('L_x)
-    	goto g
+        invalidate_origin('L_x)
+        goto g
     }
 
     g: "Vec_len(move v)" {
-    	access_origin('v)
-    	goto
+        access_origin('v)
+        goto
     }
     "###);
 }

--- a/src/polonius.dl
+++ b/src/polonius.dl
@@ -5,20 +5,20 @@
 // Inputs
 //
 // ## Assumptions about ordering
-// 
+//
 // For a given node `N`...
-// 
+//
 // * First we perform any accesses `access_origin(O, N)`
 // * Then we invalidate any origins `invalidate_origin(L, N)`
 // * Then we clear any origins `clear_origin`
 // * Then we introduce any subsets `introduce_subset`
-// 
-// This corresponds to 
-// 
+//
+// This corresponds to
+//
 // ```
 // place = expr
 // ```
-// 
+//
 // * Evaluating the expr accesses the origins (including potentially some in place)
 // * Then place is overwritten, invalidating and clearing loans
 // * Storing the value also creates subtyping relationships between the type of the value that was stored and the place it was stored into
@@ -38,7 +38,7 @@
 //     * e.g., if there is a loan `'L_*temp` where `temp: &T` and this expression writes to `temp`, then `'L_*temp` is cleared,
 //       not invalidated. This is because memory at `*temp` is not owned, so it is not freed by writing to `temp`,
 //       but `*temp` no longer names the same memory anymore.
-// * For every `&'L_P P` expression, generate `clear_origin('L_P)` 
+// * For every `&'L_P P` expression, generate `clear_origin('L_P)`
 // * If this is a `&'L_P P` for some place `P`, it is treated as a read of the place `P`:
 //     * In addition, "unroll" P to add subset relations:
 //          * If `P = *Q` where `Q: &'O T`, then `'L_P <= O` (do not continue unrolling)
@@ -81,10 +81,10 @@
 .output origin_live_on_entry
 
 // Note that accesses come before clears, so we check on the outgoing edges.
-origin_live_on_entry(O, N) :- 
+origin_live_on_entry(O, N) :-
   access_origin(O, N).
 
-origin_live_on_entry(O, N1) :- 
+origin_live_on_entry(O, N1) :-
   cfg_edge(N1, N2),
   !clear_origin(O, N1),
   origin_live_on_entry(O, N2).
@@ -111,7 +111,7 @@ subset_on_exit(O1, O3, N1) :- // Transitive closure
 
 // Carried over from predecessor.
 // Subsets are filtered from the `subset_on_exit` transitive closure.
-subset_on_entry(O1, O2, N2) :- 
+subset_on_entry(O1, O2, N2) :-
   cfg_edge(N1, N2),
   (origin_live_on_entry(O1, N2); mark_as_loan_origin(O1)),
   (origin_live_on_entry(O2, N2); mark_as_loan_origin(O2)),
@@ -126,10 +126,10 @@ origin_invalidated(O, N2) :- // Introduced by predecessor
   !clear_origin(O, N1),
   (invalidate_origin(O, N1); origin_invalidated(O, N1)).
 
-// Because invalidations conceptually happen before clears, 
+// Because invalidations conceptually happen before clears,
 // propagate them across (existing, not introduced) subset relationships
 // even if `O1` is also (conceptually later) cleared in `N1`.
-origin_invalidated(O2, N2) :- 
+origin_invalidated(O2, N2) :-
   cfg_edge(N1, N2),
   !clear_origin(O2, N1),
   subset_on_entry(O1, O2, N1),

--- a/tests/canonical-liveness-err/program.txt
+++ b/tests/canonical-liveness-err/program.txt
@@ -8,9 +8,9 @@
 // Decls
 // let p: u32
 // let x: &'x u32
-// 
+//
 // Loan origins:
-// 'L_p: `x`'s borrow of `p` 
+// 'L_p: `x`'s borrow of `p`
 
 mark_as_loan_origin('L_p)
 
@@ -27,13 +27,13 @@ b: "x = &'L_p p" {
     clear_origin('L_p)
 
     // `&'L_p u32 <: &'x u32`
-    introduce_subset('L_p, 'x) 
+    introduce_subset('L_p, 'x)
     goto c
 }
 
 c: "p += 1" {
     // Access `p` where `p: u32`
-    
+
     // Invalidate borrows of `p`
     invalidate_origin('L_p)
 

--- a/tests/canonical-liveness/program.txt
+++ b/tests/canonical-liveness/program.txt
@@ -9,9 +9,9 @@
 // let p: u32
 // let q: u32
 // let x: &'x u32
-// 
+//
 // Loan origins:
-// 'L_p: `x`'s borrow of `p` 
+// 'L_p: `x`'s borrow of `p`
 // 'L_q: `x`'s borrow of `q`
 
 mark_as_loan_origin('L_p)
@@ -35,7 +35,7 @@ c: "x = &'L_p p" {
     clear_origin('L_p)
 
     // `&'L_p u32 <: &'x u32`
-    introduce_subset('L_p, 'x) 
+    introduce_subset('L_p, 'x)
     goto d
 }
 
@@ -47,13 +47,13 @@ d: "x = &'L_q q" {
     clear_origin('L_q)
 
     // `&'L_q u32 <: &'x u32`
-    introduce_subset('L_q, 'x) 
+    introduce_subset('L_q, 'x)
     goto e
 }
 
 e: "p += 1" {
     // Access `p` where `p: u32`
-    
+
     // Invalidate borrows of `p`
     invalidate_origin('L_p)
 

--- a/tests/diamond-ref-mod/program.txt
+++ b/tests/diamond-ref-mod/program.txt
@@ -1,7 +1,7 @@
 // let mut x = 42;
 // let mut p = &22;
 // if maybe() {
-//     p = &x; // L_x 
+//     p = &x; // L_x
 // } else {
 //     x = 0;
 // }
@@ -10,10 +10,10 @@
 // Decls
 // let x: u32
 // let p: &'p u32
-// 
+//
 // Loan origins:
 // 'const: `p`'s borrow of `22`
-// 'L_x: `p`'s borrow of `x` 
+// 'L_x: `p`'s borrow of `x`
 
 mark_as_loan_origin('const)
 mark_as_loan_origin('L_x)
@@ -31,14 +31,14 @@ b: "p = &'const 22" {
     clear_origin('const)
 
     // `&'const u32 <: &'p u32`
-    introduce_subset('const, 'p) 
+    introduce_subset('const, 'p)
 
     goto c d
 }
 
 c: "p = &'L_x x" {
     // Access `x` where `x: u32`
-    
+
     // Invalidate mutable borrows of `x`
 
     // Clear all origins in `p` (overwritten plan):
@@ -48,8 +48,8 @@ c: "p = &'L_x x" {
     clear_origin('L_x)
 
     // `&'L_x u32 <: &'p u32`
-    introduce_subset('L_x, 'p) 
-    
+    introduce_subset('L_x, 'p)
+
     goto e
 }
 
@@ -57,12 +57,12 @@ d: "x = 0" {
     // Invalidate borrows of `x`
     invalidate_origin('L_x)
 
-    goto e 
+    goto e
 }
 
 e: "use(p)" {
     // Access `p` [== `&'p x`] where `x: u32`
     access_origin('p)
 
-    goto 
+    goto
 }

--- a/tests/example-a/program.txt
+++ b/tests/example-a/program.txt
@@ -8,7 +8,7 @@ a: "x = 3" {
 b: "y = &'0 x" {
     // FIXME: `y` is overwritten, so `'y` should be cleared here
     access_origin('x)
-    
+
     clear_origin('0)
     introduce_subset('0, 'y)
     goto c

--- a/tests/killing-and-murder-err/program.txt
+++ b/tests/killing-and-murder-err/program.txt
@@ -3,16 +3,16 @@
 // let p = 22;
 // let mut x: &mut i32 = &mut p; // `x` points at `p`
 // let y = &mut *x; // `y` points at `p` too
-// use(x); 
+// use(x);
 // *y = 11; // ERROR: both `x` and `y` are used
 
 // Decls
 // let p: u32
 // let x: &'x mut u32
 // let y: &'y mut u32
-// 
+//
 // Loan origins:
-// 'L_p: `x`'s borrow of `p` 
+// 'L_p: `x`'s borrow of `p`
 // 'L_*x: `y`'s borrow of `*x`
 
 mark_as_loan_origin('L_p)
@@ -31,7 +31,7 @@ b: "x = &'L_p mut p" {
     clear_origin('L_p)
 
     // `&'L_p mut u32 <: &'x mut u32`
-    introduce_subset('L_p, 'x) 
+    introduce_subset('L_p, 'x)
     goto c
 }
 
@@ -50,7 +50,7 @@ c: "y = &'L_*x mut *x" {
     introduce_subset('x, 'L_*x)
 
     // `&'L_*x mut u32 <: &'y mut u32`
-    introduce_subset('L_*x, 'y) 
+    introduce_subset('L_*x, 'y)
     goto d
 }
 

--- a/tests/killing-and-murder/program.txt
+++ b/tests/killing-and-murder/program.txt
@@ -12,9 +12,9 @@
 // let q: u32
 // let x: &'x mut u32
 // let y: &'y mut u32
-// 
+//
 // Loan origins:
-// 'L_p: `x`'s borrow of `p` 
+// 'L_p: `x`'s borrow of `p`
 // 'L_*x: `y`'s borrow of `*x`
 // 'L_q: `x`'s borrow of `q`
 
@@ -40,7 +40,7 @@ c: "x = &'L_p mut p" {
     clear_origin('L_p)
 
     // `&'L_p mut u32 <: &'x mut u32`
-    introduce_subset('L_p, 'x) 
+    introduce_subset('L_p, 'x)
     goto d
 }
 
@@ -59,7 +59,7 @@ d: "y = &'L_*x mut *x" {
     introduce_subset('x, 'L_*x)
 
     // `&'L_*x mut u32 <: &'y mut u32`
-    introduce_subset('L_*x, 'y) 
+    introduce_subset('L_*x, 'y)
     goto e
 }
 
@@ -74,7 +74,7 @@ e: "x = &'L_q mut q" {
     clear_origin('L_*x)
 
     // `&'L_q mut u32 <: &'x mut u32`
-    introduce_subset('L_q, 'x) 
+    introduce_subset('L_q, 'x)
     goto f
 }
 

--- a/tests/self-invalidation-loop-shared/program.txt
+++ b/tests/self-invalidation-loop-shared/program.txt
@@ -3,9 +3,9 @@
 // let mut x = 42;
 // let mut v: Vec<&u32> = vec![];
 // while maybe() {
-//     let p = &x; // L_x 
+//     let p = &x; // L_x
 //     let v_tmp = &mut v; // L_v
-//     Vec::push(v_tmp, p); 
+//     Vec::push(v_tmp, p);
 // }
 
 // Decls
@@ -13,9 +13,9 @@
 // let v: Vec<&'v u32>
 // let p: &'p u32
 // let v_tmp: &'tmp0 Vec<&'tmp1 u32>
-// 
+//
 // Loan origins:
-// 'L_x: `p`'s borrow of `x` 
+// 'L_x: `p`'s borrow of `x`
 // 'L_v: temporary borrow of `v` for `Vec::push`
 
 mark_as_loan_origin('L_x)
@@ -41,15 +41,15 @@ c: "p = &'L_x x" {
     clear_origin('L_x)
 
     // `&'L_x u32 <: &'p u32`
-    introduce_subset('L_x, 'p) 
-    
+    introduce_subset('L_x, 'p)
+
     goto d
 }
 
 d: "v_tmp = &'L_v mut v" {
     // Access `v` where `v: Vec<&'v u32>`
     access_origin('v)
-    
+
     // Invalidate borrows of `v`
     invalidate_origin('L_v)
 
@@ -65,14 +65,14 @@ d: "v_tmp = &'L_v mut v" {
     introduce_subset('tmp1, 'v)
     introduce_subset('v, 'tmp1)
 
-    goto e 
+    goto e
 }
 
 e: "Vec::push(v_tmp, p)" {
     // Access `v_tmp` [== `&'tmp1 mut v`] where `v_tmp: &'tmp0 mut Vec<&'tmp1 u32>`
     access_origin('tmp0)
     access_origin('tmp1)
-    
+
     // Access `p` [== `&x`] where `p: &'p u32`
     access_origin('p)
 

--- a/tests/self-invalidation-loop/program.txt
+++ b/tests/self-invalidation-loop/program.txt
@@ -1,9 +1,9 @@
 // let mut x = 42;
 // let mut v: Vec<&mut u32> = vec![];
 // while maybe() {
-//     let p = &mut x; // L_x 
+//     let p = &mut x; // L_x
 //     let v_tmp = &mut v; // L_v // ERROR on second iteration because `v` is used but `x` was borrowed again
-//     Vec::push(v_tmp, p); 
+//     Vec::push(v_tmp, p);
 // }
 
 // Decls
@@ -11,9 +11,9 @@
 // let v: Vec<&'v mut u32>
 // let p: &'p mut u32
 // let v_tmp: &'tmp0 mut Vec<&'tmp1 mut u32>
-// 
+//
 // Loan origins:
-// 'L_x: `p`'s borrow of `x` 
+// 'L_x: `p`'s borrow of `x`
 // 'L_v: temporary borrow of `v` for `Vec::push`
 
 mark_as_loan_origin('L_x)
@@ -31,7 +31,7 @@ b: "v = vec![]" {
 
 c: "p = &'L_x mut x" {
     // Access `x` where `x: u32`
-    
+
     // Invalidate borrows of `x`
     invalidate_origin('L_x)
 
@@ -42,15 +42,15 @@ c: "p = &'L_x mut x" {
     clear_origin('L_x)
 
     // `&'L_x mut u32 <: &'p mut u32`
-    introduce_subset('L_x, 'p) 
-    
+    introduce_subset('L_x, 'p)
+
     goto d
 }
 
 d: "v_tmp = &'L_v mut v" {
     // Access `v` where `v: Vec<&'v mut u32>`
     access_origin('v)
-    
+
     // Invalidate borrows of `v`
     invalidate_origin('L_v)
 
@@ -66,19 +66,19 @@ d: "v_tmp = &'L_v mut v" {
     introduce_subset('tmp1, 'v)
     introduce_subset('v, 'tmp1)
 
-    goto e 
+    goto e
 }
 
 e: "Vec::push(v_tmp, p)" {
     // Access `v_tmp` [== `&'tmp1 mut v`] where `v_tmp: &'tmp0 mut Vec<&'tmp1 mut u32>`
     access_origin('tmp0)
     access_origin('tmp1)
-    
+
     // Access `p` [== `&mut x`] where `p: &'p mut u32`
     access_origin('p)
 
     // Signature requires `&'p mut u32` <: `&'tmp1 mut u32`:
     introduce_subset('p, 'tmp1)
 
-    goto c 
+    goto c
 }

--- a/tests/vec-temp/program.txt
+++ b/tests/vec-temp/program.txt
@@ -39,7 +39,7 @@ c: "p = &'L_x x" {
     clear_origin('L_x)
 
     // `&'L_x u32 <: &'p u32`
-    introduce_subset('L_x, 'p) 
+    introduce_subset('L_x, 'p)
     goto d
 }
 


### PR DESCRIPTION
...and ensure they do not return in CI.

This way I can `:wq` from vim without running `git checkout -p` right after.